### PR TITLE
Fixes issue when you have multiple addons where they appear at the same time.

### DIFF
--- a/src/component/LiveEditor/index.js
+++ b/src/component/LiveEditor/index.js
@@ -45,8 +45,8 @@ class LiveEditor extends React.Component<LiveEditorProps, LiveEditorState> {
         this.codemirrorValueChanged = this.codemirrorValueChanged.bind(this);
     }
 
-    shouldComponentUpdate(_: any, state: LiveEditorState): boolean {
-        return this.state.theme !== state.theme || Boolean(this.state.code) !== Boolean(state.code);
+    shouldComponentUpdate(nextProps: LiveEditorProps, state: LiveEditorState): boolean {
+        return this.props.active !== nextProps.active || this.state.theme !== state.theme || Boolean(this.state.code) !== Boolean(state.code);
     }
 
     loadSource(code: string) {


### PR DESCRIPTION
Reraising https://github.com/vertexbz/storybook-addon-react-live-edit/issues/2 which was closed as I am still experiencing the problem.

**Steps to reproduce the issue:**
1. Create storybook with `storybook-addon-react-live-edit addon` plus another addon, for example knobs. Have live-edit as the first addon.
2. Load storybook, the live-edit addon is loaded, click on the knobs tab.
**Actual**: live-edit does not unload, both addons display
**Expected**: When live-edit is not the active addon tab it should not display.
